### PR TITLE
Depend on @tryjsky/ntlm2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# smb2,support ntlm2.Base project https://github.com/Node-SMB/marsaud-smb2
+# Diff
+
+[v9u-smb2](https://github.com/v9u/v9u-smb2) with Node v17 patch.
 
 # SMB2 Client for Node.js
 

--- a/package.json
+++ b/package.json
@@ -1,24 +1,24 @@
 {
-  "name": "v9u-smb2",
-  "description": "smb2,support ntlm2.Base project https://github.com/Node-SMB/marsaud-smb2",
-  "homepage": "https://github.com/v9u/v9u-smb2",
-  "version": "1.0.6",
+  "name": "@tryjsky/v9u-smb2",
+  "description": "v9u-smb2 with Node v17 patch",
+  "homepage": "https://github.com/tryjsky/v9u-smb2",
+  "version": "1.0.7",
   "engines": {
     "node": ">=10"
   },
   "author": {
-    "name": "v9u",
-    "email": "2808949242@qq.com",
-    "url": "https://github.com/v9u"
+    "name": "Y., Ryota",
+    "email": "tryjsky@gmail.com",
+    "url": "https://github.com/tryjsky"
   },
   "types": "index.d.ts",
   "main": "lib/smb2.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/v9u/v9u-smb2"
+    "url": "https://github.com/tryjsky/v9u-smb2"
   },
   "dependencies": {
-    "ntlm2": "^0.3.0",
+    "@tryjsky/ntlm2": "^0.3.1",
     "readable-stream": "^3.6.0"
   },
   "keywords": [


### PR DESCRIPTION
Original package was not compatible with Node v17, so I changed the dependent package to @tryjsky/ntlm2.